### PR TITLE
Organize AST definitions into header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ parser.tab.cpp parser.tab.h: parser.y
 lex.yy.c: lexer.l parser.tab.h
 	flex -o lex.yy.c lexer.l
 
-parser.tab.o: parser.tab.cpp symbol_table.h
+parser.tab.o: parser.tab.cpp symbol_table.h ast.h
 	$(CXX) $(CXXFLAGS) -c parser.tab.cpp
 
 lex.yy.o: lex.yy.c parser.tab.h
 	$(CXX) $(CXXFLAGS) -c lex.yy.c
 
-main.o: main.cpp parser.tab.h symbol_table.h
+main.o: main.cpp parser.tab.h symbol_table.h ast.h
 	$(CXX) $(CXXFLAGS) -c main.cpp
 
 symbol_table.o: symbol_table.cpp symbol_table.h

--- a/ast.h
+++ b/ast.h
@@ -1,0 +1,142 @@
+#ifndef AST_H
+#define AST_H
+
+#include <string>
+#include <vector>
+#include "symbol_table.h"
+
+class Expression {
+public:
+    virtual ~Expression() {}
+    virtual int eval(SymbolTable& sym) const = 0;
+};
+
+class NumberExpr : public Expression {
+public:
+    int value;
+    NumberExpr(int v):value(v){}
+    int eval(SymbolTable&) const override { return value; }
+};
+
+class VariableExpr : public Expression {
+public:
+    std::string name;
+    VariableExpr(const std::string &n):name(n){}
+    int eval(SymbolTable& sym) const override {
+        int v;
+        if(!sym.get_variable(name,v)) {
+            fprintf(stderr, "Undefined variable %s\n", name.c_str());
+            return 0;
+        }
+        return v;
+    }
+};
+
+class BinaryExpr : public Expression {
+public:
+    int op; //1==,2>,3<
+    Expression *left,*right;
+    BinaryExpr(int o, Expression* l, Expression* r):op(o),left(l),right(r){}
+    ~BinaryExpr(){ delete left; delete right; }
+    int eval(SymbolTable& sym) const override {
+        int lv=left->eval(sym), rv=right->eval(sym);
+        switch(op){
+            case 1: return lv==rv;
+            case 2: return lv>rv;
+            case 3: return lv<rv;
+        }
+        return 0;
+    }
+};
+
+class Statement {
+public:
+    virtual ~Statement(){}
+    virtual void exec(SymbolTable& sym) const = 0;
+};
+
+class IntDeclStmt : public Statement {
+public:
+    std::string name;
+    IntDeclStmt(const std::string &n):name(n){}
+    void exec(SymbolTable& sym) const override {
+        if(!sym.add_variable(name))
+            fprintf(stderr, "Variable %s already declared\n", name.c_str());
+    }
+};
+
+class AssignStmt : public Statement {
+public:
+    std::string name;
+    Expression* expr;
+    AssignStmt(const std::string &n, Expression* e):name(n),expr(e){}
+    ~AssignStmt(){ delete expr; }
+    void exec(SymbolTable& sym) const override {
+        int v = expr->eval(sym);
+        if(!sym.set_variable(name,v))
+            fprintf(stderr, "Undefined variable %s\n", name.c_str());
+    }
+};
+
+class PrintStmt : public Statement {
+public:
+    std::string text;
+    PrintStmt(const std::string &t):text(t){}
+    void exec(SymbolTable&) const override { printf("%s\n", text.c_str()); }
+};
+
+class SendUdsStmt : public Statement {
+public:
+    std::string text;
+    SendUdsStmt(const std::string &t):text(t){}
+    void exec(SymbolTable&) const override { printf("senduds: %s\n", text.c_str()); }
+};
+
+class ReadDidStmt : public Statement {
+public:
+    std::string text;
+    ReadDidStmt(const std::string &t):text(t){}
+    void exec(SymbolTable&) const override { printf("readdid: %s\n", text.c_str()); }
+};
+
+class BlockStmt : public Statement {
+public:
+    std::vector<Statement*> stmts;
+    ~BlockStmt(){ for(auto s:stmts) delete s; }
+    void exec(SymbolTable& sym) const override {
+        for(auto s:stmts) s->exec(sym);
+    }
+};
+
+class IfStmt : public Statement {
+public:
+    Expression* cond;
+    BlockStmt* block;
+    IfStmt(Expression* c, BlockStmt* b):cond(c),block(b){}
+    ~IfStmt(){ delete cond; delete block; }
+    void exec(SymbolTable& sym) const override {
+        if(cond->eval(sym)) block->exec(sym);
+    }
+};
+
+class WhileStmt : public Statement {
+public:
+    Expression* cond;
+    BlockStmt* block;
+    WhileStmt(Expression* c, BlockStmt* b):cond(c),block(b){}
+    ~WhileStmt(){ delete cond; delete block; }
+    void exec(SymbolTable& sym) const override {
+        while(cond->eval(sym)) block->exec(sym);
+    }
+};
+
+class Program {
+public:
+    std::vector<Statement*> stmts;
+    ~Program(){ for(auto s:stmts) delete s; }
+    void exec(SymbolTable& sym) const {
+        for(auto s:stmts) s->exec(sym);
+    }
+};
+
+#endif // AST_H

--- a/main.cpp
+++ b/main.cpp
@@ -1,12 +1,9 @@
 #include <cstdio>
 #include <cstdlib>
 
+#include "ast.h"
 extern int yyparse();
 extern FILE* yyin;
-
-class Program; // forward
-class SymbolTable; // forward
-
 Program* get_root();
 SymbolTable& get_symtab();
 

--- a/parser.y
+++ b/parser.y
@@ -1,143 +1,7 @@
 %{
 #include <cstdio>
 #include <cstdlib>
-#include <string>
-#include <vector>
-#include "symbol_table.h"
-
-class Expression {
-public:
-    virtual ~Expression() {}
-    virtual int eval(SymbolTable& sym) const = 0;
-};
-
-class NumberExpr : public Expression {
-public:
-    int value;
-    NumberExpr(int v):value(v){}
-    int eval(SymbolTable&) const override { return value; }
-};
-
-class VariableExpr : public Expression {
-public:
-    std::string name;
-    VariableExpr(const std::string &n):name(n){}
-    int eval(SymbolTable& sym) const override {
-        int v;
-        if(!sym.get_variable(name,v)) {
-            fprintf(stderr, "Undefined variable %s\n", name.c_str());
-            return 0;
-        }
-        return v;
-    }
-};
-
-class BinaryExpr : public Expression {
-public:
-    int op; //1==,2>,3<
-    Expression *left,*right;
-    BinaryExpr(int o, Expression* l, Expression* r):op(o),left(l),right(r){}
-    ~BinaryExpr(){ delete left; delete right; }
-    int eval(SymbolTable& sym) const override {
-        int lv=left->eval(sym), rv=right->eval(sym);
-        switch(op){
-            case 1: return lv==rv;
-            case 2: return lv>rv;
-            case 3: return lv<rv;
-        }
-        return 0;
-    }
-};
-
-class Statement {
-public:
-    virtual ~Statement(){}
-    virtual void exec(SymbolTable& sym) const = 0;
-};
-
-class IntDeclStmt : public Statement {
-public:
-    std::string name;
-    IntDeclStmt(const std::string &n):name(n){}
-    void exec(SymbolTable& sym) const override {
-        if(!sym.add_variable(name))
-            fprintf(stderr, "Variable %s already declared\n", name.c_str());
-    }
-};
-
-class AssignStmt : public Statement {
-public:
-    std::string name;
-    Expression* expr;
-    AssignStmt(const std::string &n, Expression* e):name(n),expr(e){}
-    ~AssignStmt(){ delete expr; }
-    void exec(SymbolTable& sym) const override {
-        int v = expr->eval(sym);
-        if(!sym.set_variable(name,v))
-            fprintf(stderr, "Undefined variable %s\n", name.c_str());
-    }
-};
-
-class PrintStmt : public Statement {
-public:
-    std::string text;
-    PrintStmt(const std::string &t):text(t){}
-    void exec(SymbolTable&) const override { printf("%s\n", text.c_str()); }
-};
-
-class SendUdsStmt : public Statement {
-public:
-    std::string text;
-    SendUdsStmt(const std::string &t):text(t){}
-    void exec(SymbolTable&) const override { printf("senduds: %s\n", text.c_str()); }
-};
-
-class ReadDidStmt : public Statement {
-public:
-    std::string text;
-    ReadDidStmt(const std::string &t):text(t){}
-    void exec(SymbolTable&) const override { printf("readdid: %s\n", text.c_str()); }
-};
-
-class BlockStmt : public Statement {
-public:
-    std::vector<Statement*> stmts;
-    ~BlockStmt(){ for(auto s:stmts) delete s; }
-    void exec(SymbolTable& sym) const override {
-        for(auto s:stmts) s->exec(sym);
-    }
-};
-
-class IfStmt : public Statement {
-public:
-    Expression* cond;
-    BlockStmt* block;
-    IfStmt(Expression* c, BlockStmt* b):cond(c),block(b){}
-    ~IfStmt(){ delete cond; delete block; }
-    void exec(SymbolTable& sym) const override {
-        if(cond->eval(sym)) block->exec(sym);
-    }
-};
-
-class WhileStmt : public Statement {
-public:
-    Expression* cond;
-    BlockStmt* block;
-    WhileStmt(Expression* c, BlockStmt* b):cond(c),block(b){}
-    ~WhileStmt(){ delete cond; delete block; }
-    void exec(SymbolTable& sym) const override {
-        while(cond->eval(sym)) block->exec(sym);
-    }
-};
-
-class Program {
-public:
-    std::vector<Statement*> stmts;
-    ~Program(){ for(auto s:stmts) delete s; }
-    void exec(SymbolTable& sym) const {
-        for(auto s:stmts) s->exec(sym);
-    }
-};
+#include "ast.h"
 
 static Program* root;
 static SymbolTable symtab;
@@ -145,6 +9,13 @@ static SymbolTable symtab;
 void yyerror(const char* s);
 int yylex(void);
 %}
+
+%code requires {
+class Expression;
+class Statement;
+class BlockStmt;
+class Program;
+}
 
 %union {
     int ival;


### PR DESCRIPTION
## Summary
- move all AST class definitions from `parser.y` to new `ast.h`
- include `ast.h` in `parser.y` and `main.cpp`
- update Makefile dependencies for the new header

## Testing
- `make` *(fails: bison not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e908319e48329afb4e25870553a6c